### PR TITLE
fixed bug that caused int overflow on 32bit systems

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -364,7 +364,7 @@ func NewFrame(tm time.Time, evtnum Evtnum, v0 float64, v1 int64, data []byte) (*
 		return nil, EvtnumOutOfRangeErr
 	}
 
-	if len(data) > (1<<43)-1 {
+	if int64(len(data)) > (1<<43)-1 {
 		return nil, DataTooBigErr
 	}
 


### PR DESCRIPTION
Hi, I use https://github.com/glycerine/zygomys for a project.  Recently when trying to compile it on a raspberry pi, and the dependency on this package caused it to fail. 

This pull request fixes the issue.